### PR TITLE
Update NodeJS APT repo file name

### DIFF
--- a/nodejs/tasks/main.yml
+++ b/nodejs/tasks/main.yml
@@ -13,7 +13,7 @@
   apt_repository:
     repo: deb https://deb.nodesource.com/node_{{ version }}.x xenial main
     state: present
-    filename: nodejs
+    filename: nodesource
 
 - name: Install NodeJS
   apt:


### PR DESCRIPTION
Update NodeJS APT repo file name to match what is defined in the official install script.

CF https://deb.nodesource.com/setup_12.x