### PR TITLE
Replace hard-coded xenial with remote distro codename

### DIFF
--- a/nodejs/tasks/main.yml
+++ b/nodejs/tasks/main.yml
@@ -11,7 +11,7 @@
 
 - name: Add NodeJS APT repo
   apt_repository:
-    repo: deb https://deb.nodesource.com/node_{{ version }}.x xenial main
+    repo: deb https://deb.nodesource.com/node_{{ version }}.x {{ ansible_distribution_release }} main
     state: present
     filename: nodesource
 


### PR DESCRIPTION
This enables the use of the nodejs role on the latest Ubuntu LTS,
without breaking it on older distributions.