### PR TITLE
This makes the cerbot install compatible with Ubuntu 20.04

### DIFF
--- a/letsencrypt/tasks/main.yml
+++ b/letsencrypt/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Add certbot repository
   apt_repository:
     repo: 'ppa:certbot/certbot'
-  when: ansible_distribution == 'Ubuntu'
+  when: ansible_distribution == 'Ubuntu' and ansible_distribution_release != "focal"
 
 - name: Install certbot package
   apt:


### PR DESCRIPTION
`certbot` being already in the Focal repositories render the first step
useless (in fact, it causes errors on Focal).