### PR TITLE
[BC Break] Add version to PHP socket path

### DIFF
--- a/php_fpm_pool/templates/pool.conf.j2
+++ b/php_fpm_pool/templates/pool.conf.j2
@@ -3,7 +3,7 @@
 user = {{ user }}
 group = {{ group }}
 
-listen = /var/run/php/{{ pool }}.sock
+listen = /run/php/{{ version }}/{{ pool }}.sock
 listen.owner = www-data
 listen.group = www-data
 


### PR DESCRIPTION
This is a BC break, but it will allow doing PHP version updates without downtime where previously we had to remove the previous PHP version and then install the new one.