### PR TITLE
Update PHP socket path.

### DIFF
--- a/php_fpm_pool/templates/pool.conf.j2
+++ b/php_fpm_pool/templates/pool.conf.j2
@@ -3,7 +3,7 @@
 user = {{ user }}
 group = {{ group }}
 
-listen = /run/php/{{ version }}/{{ pool }}.sock
+listen = /run/php/{{ pool }}-{{ version }}.sock
 listen.owner = www-data
 listen.group = www-data
 


### PR DESCRIPTION
Update PHP socket path to use a suffix instead of separate directory. This fix a problem with PHP not beeing able to create the socket since the directory doesn't exists.