### PR TITLE
Enable gzip for assets

### DIFF
--- a/nginx/files/gzip.conf
+++ b/nginx/files/gzip.conf
@@ -1,0 +1,2 @@
+gzip on;
+gzip_types text/css text/javascript;

--- a/nginx/tasks/main.yml
+++ b/nginx/tasks/main.yml
@@ -12,6 +12,14 @@
   notify:
     - reload nginx
 
+- name: Add gzip configuration
+  copy:
+    dest: /etc/nginx/conf.d/gzip.conf
+    src: gzip.conf
+    mode: 0644
+  notify:
+    - reload nginx
+
 - name: Remove sites configuration
   file:
     path: /etc/nginx/sites-available/{{ item.key }}


### PR DESCRIPTION
By default gzip is only enable for HTML, this enable gzip for CSS and JS in addition.