### PR TITLE
Configure variables_order in CLI to

### DIFF
--- a/php_fpm_pool/tasks/main.yml
+++ b/php_fpm_pool/tasks/main.yml
@@ -10,9 +10,12 @@
 
 - name: Configure variables_order
   lineinfile:
-    path: /etc/php/{{ version }}/fpm/php.ini
+    path: /etc/php/{{ version }}/{{ item }}/php.ini
     regexp: '^;?variables_order ?='
     line: variables_order = "EGPCS"
+  loop:
+   - cli
+   - fpm
   notify:
     - restart php-fpm
 


### PR DESCRIPTION
Because we use PHP in CLI to (for console commands).