### PR TITLE
Fix certbot install on some ubuntu distrib

### DIFF
--- a/letsencrypt/tasks/main.yml
+++ b/letsencrypt/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Add certbot repository
   apt_repository:
     repo: 'ppa:certbot/certbot'
-  when: ansible_distribution == 'Ubuntu' and ansible_distribution_release != "focal"
+  when: ansible_distribution == 'Ubuntu' and ansible_distribution_release is in ["xenial", "bionic"]
 
 - name: Install certbot package
   apt:


### PR DESCRIPTION
certbot PPA is only available on wenial and bionic so we should use a whitelist instead of a blacklist for determinint if we should use the PPA or fallback to the OS packages instead of having to manualy disallow some distributions.