### PR TITLE
Generate release name only once

### DIFF
--- a/deploy/tasks/main.yaml
+++ b/deploy/tasks/main.yaml
@@ -20,9 +20,15 @@
     msg: 'Specified artifact could not be found: {{ artifact }}'
   when: artifact_file is not defined and (artifact_url | length) == 0
 
+- name: Generate release name
+  set_fact:
+    release: '{{ now(utc=True, fmt="%Y%m%d%H%M%S") }}'
+  run_once: true
+
 - name: Initialize the deploy
   deploy_helper:
     path: '{{ path }}'
+    release: '{{ release }}'
 
 - name: Create release directory
   file:


### PR DESCRIPTION
When deploying on multiple server, the release name was generating independently on each server which could result in a diferent release name on each server.