### PR TITLE
Add role to deploy a github artifact

### DIFF
--- a/deploy_artifact/defaults/main.yaml
+++ b/deploy_artifact/defaults/main.yaml
@@ -1,0 +1,5 @@
+---
+artifact_url: ~
+shared_paths: []
+before_finalize: []
+after_finalize: []

--- a/deploy_artifact/tasks/main.yaml
+++ b/deploy_artifact/tasks/main.yaml
@@ -1,0 +1,73 @@
+---
+- name: Generate release name
+  ansible.builtin.set_fact:
+    release: '{{ now(utc=True, fmt="%Y%m%d%H%M%S") }}'
+  run_once: true
+
+- name: Initialize the deploy
+  ansible.builtin.deploy_helper:
+    path: '{{ path }}'
+    release: '{{ release }}'
+
+- name: Create release directory
+  ansible.builtin.file:
+    path: '{{ deploy_helper.new_release_path }}'
+    state: directory
+    mode: 0755
+
+- name: Add an unfinished file
+  ansible.builtin.file:
+    path: '{{ deploy_helper.new_release_path }}/{{ deploy_helper.unfinished_filename }}'
+    state: touch
+    mode: 0644
+
+- name: Upload the archive
+  ansible.builtin.copy:
+    src: '{{ artifact_url | urlsplit("path") }}'
+    dest: '{{ deploy_helper.new_release_path }}/archive'
+    mode: 0644
+  when: artifact_url is ansible.builtin.url(schemes=["file"])
+
+- name: Download the archive
+  ansible.builtin.get_url:
+    url: '{{ artifact_url }}'
+    dest: '{{ deploy_helper.new_release_path }}/archive'
+    headers: '{{ artifact_headers }}'
+    mode: 0644
+  when: artifact_url is ansible.builtin.url(schemes=["ftp", "http", "https"])
+
+- name: Extract the archive
+  ansible.builtin.unarchive:
+    remote_src: true
+    src: '{{ deploy_helper.new_release_path }}/archive'
+    dest: '{{ deploy_helper.new_release_path }}'
+
+- name: Remove the archive
+  ansible.builtin.file:
+    path: '{{ deploy_helper.new_release_path }}/archive'
+    state: absent
+
+- name: Link the shared paths
+  ansible.builtin.file:
+    path: '{{ deploy_helper.new_release_path }}/{{ item }}'
+    state: link
+    src: '{{ deploy_helper.shared_path }}/{{ item }}'
+  with_items: '{{ shared_paths }}'
+
+- name: Run before_finalize commands
+  ansible.builtin.shell: '{{ item }}' # noqa command-instead-of-shell no-changed-when
+  args:
+    chdir: '{{ deploy_helper.new_release_path }}'
+  with_items: '{{ before_finalize }}'
+
+- name: Finalize the deploy
+  ansible.builtin.deploy_helper:
+    path: '{{ deploy_helper.project_path }}'
+    release: '{{ deploy_helper.new_release }}'
+    state: finalize
+
+- name: Run after_finalize commands
+  ansible.builtin.shell: '{{ item }}' # noqa command-instead-of-shell no-changed-when
+  args:
+    chdir: '{{ deploy_helper.new_release_path }}'
+  with_items: '{{ after_finalize }}'

--- a/find_github_artifact/tasks/main.yaml
+++ b/find_github_artifact/tasks/main.yaml
@@ -1,0 +1,62 @@
+---
+- name: Fetch commits
+  ansible.builtin.uri:
+    url: https://api.github.com/repos/{{ repository_name }}/commits?sha={{ branch }}
+    headers:
+      accept: application/vnd.github+json
+      authorization: Bearer {{ github_token }}
+      x-github-api-version: '2022-11-28'
+  register: commits
+
+- name: Get commit
+  ansible.builtin.set_fact:
+    last_commit: '{{ commits.json[0] }}'
+
+- name: Fetch workflows
+  ansible.builtin.uri:
+    url: https://api.github.com/repos/{{ repository_name }}/actions/workflows
+    headers:
+      accept: application/vnd.github+json
+      authorization: Bearer {{ github_token }}
+      x-github-api-version: '2022-11-28'
+  register: workflows
+
+- name: Get workflow
+  ansible.builtin.set_fact:
+    workflow: '{{ workflows.json | community.general.json_query(query) }}'
+  vars:
+    query: 'workflows[?path==`.github/workflows/{{ workflow_name }}.yaml`] | [0]'
+
+- name: Fetch runs
+  ansible.builtin.uri:
+    url: https://api.github.com/repos/{{ repository_name }}/actions/workflows/{{ workflow.id }}/runs?head_sha={{ last_commit.sha }}
+    headers:
+      accept: application/vnd.github+json
+      authorization: Bearer {{ github_token }}
+      x-github-api-version: '2022-11-28'
+  register: runs
+
+- name: Get run
+  ansible.builtin.set_fact:
+    last_run: '{{ (runs.json.workflow_runs | sort(attribute="created_at"))[-1] }}'
+
+- name: Fetch artifacts
+  ansible.builtin.uri:
+    url: '{{ last_run.artifacts_url }}'
+    headers:
+      accept: application/vnd.github+json
+      authorization: Bearer {{ github_token }}
+      x-github-api-version: '2022-11-28'
+  register: artifacts
+
+- name: Get artifact
+  ansible.builtin.set_fact:
+    artifact: '{{ artifacts.json.artifacts[0] }}'
+
+- name: Set variables
+  ansible.builtin.set_fact:
+    artifact_url: '{{ artifact.archive_download_url }}'
+    artifact_headers:
+      accept: application/vnd.github+json
+      authorization: Bearer {{ github_token }}
+      x-github-api-version: '2022-11-28'


### PR DESCRIPTION
This PR adds two new roles that can be used to deploy a GitHub artifact:
 - The first is a generic `deploy_artifact` that takes an URL (that can use the `file://` scheme for local files) and deploys it to the server.
 - The second is the `find_github_artifact` that takes a repository, workflow and github token to search the artifact and set the right variables to allow the `deploy_artifact` to run after it.
 
 I created new roles instead of reusing the `build` and `deploy` roles to not break BC since most of the parameters used changed.
 
 It might be usefull to create a "find artifact" role for other CIs, especially CircleCI since it would allow migrating from the old roles without having to migrate the whole CI to GHA but this can be done if needed in another PR.