### PR TITLE
Improve find_github_artifact role

### DIFF
--- a/deploy_artifact/defaults/main.yaml
+++ b/deploy_artifact/defaults/main.yaml
@@ -1,4 +1,5 @@
 ---
+artifact_headers: {}
 artifact_url: ~
 shared_paths: []
 before_finalize: []

--- a/find_github_artifact/tasks/main.yaml
+++ b/find_github_artifact/tasks/main.yaml
@@ -6,6 +6,7 @@
       accept: application/vnd.github+json
       authorization: Bearer {{ github_token }}
       x-github-api-version: '2022-11-28'
+  check_mode: false
   register: commits
 
 - name: Get commit
@@ -19,13 +20,14 @@
       accept: application/vnd.github+json
       authorization: Bearer {{ github_token }}
       x-github-api-version: '2022-11-28'
+  check_mode: false
   register: workflows
 
 - name: Get workflow
   ansible.builtin.set_fact:
     workflow: '{{ workflows.json | community.general.json_query(query) }}'
   vars:
-    query: 'workflows[?path==`.github/workflows/{{ workflow_name }}.yaml`] | [0]'
+    query: 'workflows[?path==`.github/workflows/{{ workflow_file }}`] | [0]'
 
 - name: Fetch runs
   ansible.builtin.uri:
@@ -34,6 +36,7 @@
       accept: application/vnd.github+json
       authorization: Bearer {{ github_token }}
       x-github-api-version: '2022-11-28'
+  check_mode: false
   register: runs
 
 - name: Get run
@@ -47,16 +50,25 @@
       accept: application/vnd.github+json
       authorization: Bearer {{ github_token }}
       x-github-api-version: '2022-11-28'
+  check_mode: false
   register: artifacts
 
 - name: Get artifact
   ansible.builtin.set_fact:
     artifact: '{{ artifacts.json.artifacts[0] }}'
 
-- name: Set variables
-  ansible.builtin.set_fact:
-    artifact_url: '{{ artifact.archive_download_url }}'
-    artifact_headers:
+- name: Get the download URL of the artifact
+  ansible.builtin.uri:
+    url: '{{ artifact.archive_download_url }}'
+    follow_redirects: none
+    headers:
       accept: application/vnd.github+json
       authorization: Bearer {{ github_token }}
       x-github-api-version: '2022-11-28'
+    status_code:
+      - 302
+  register: artifact_download
+
+- name: Set variables
+  ansible.builtin.set_fact:
+    artifact_url: '{{ artifact_download.location }}'


### PR DESCRIPTION
- Add `check_mode: false` to GET request to allow running the role in check mode.
- Remplace `workflow_name` parameter with `workflow_file` :
  - The old name could be confused with the `name` attribute in the workflow file.
  - If you use the `yml` extension you couldn't target the workflow file (but why would you do that unless you where on windows 3.1)
- Resolve download redirection before passing the URL to the next role.